### PR TITLE
Fix body-parser usage

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,7 +9,8 @@ var nodemailer = require('nodemailer')
 var app = express();
 var compiler = webpack(config);
 
-app.use( bodyParser() );
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
 
 app.use(require('webpack-dev-middleware')(compiler, {
   publicPath: config.output.publicPath


### PR DESCRIPTION
## Summary
- properly configure Express to parse POST bodies

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm start` *(fails: missing module 'webpack')*

------
https://chatgpt.com/codex/tasks/task_e_6845f469d1d0832ab0e4048394714188